### PR TITLE
Add 'pan' mode to Wheel layer

### DIFF
--- a/src/Wheel.js
+++ b/src/Wheel.js
@@ -34,26 +34,27 @@ po.wheel = function() {
 
     /* Detect the pixels that would be scrolled by this wheel event. */
     if (deltaY) {
+      /* smooth zooming must be enabled for 'pan' mode */
       if (smooth) {
-        if (e.axis && e.axis === e.HORIZONTAL_AXIS) {
+        /* 1 means horizontal movement, 2 means vertical */
+        if (e.axis === 1) {
           deltaX = deltaY;
           deltaY = 0;
         }
-        try {
-          outer.scrollTop = 1000;
-          outer.scrollLeft = 1000;
-          outer.dispatchEvent(e);
-          deltaY = 1000 - outer.scrollTop;
-          deltaX = 1000 - outer.scrollLeft;
-        } catch (error) {
-          // Derp! Hope for the best?
+        else {
+          try {
+            outer.scrollTop = 1000;
+            outer.scrollLeft = 1000;
+            outer.dispatchEvent(e);
+            deltaY = 1000 - outer.scrollTop;
+            deltaX = 1000 - outer.scrollLeft;
+          } catch (error) {
+            // Derp! Hope for the best?
+          }
         }
 
         if (zoom !== 'pan') {
-          deltaY = Math.sqrt(deltaY*deltaY+deltaX*deltaX) // length of scroll
-                  * ((deltaY > deltaX && deltaY > 0) || (deltaY < deltaX && deltaX > 0) ? 1 : -1) // direction of scroll
-                  * .005 // arbitrary scale factor
-                  ;
+          deltaY *= .005;
         }
       }
 
@@ -68,7 +69,6 @@ po.wheel = function() {
         }
       }
     }
-
 
     if (deltaY || deltaX) {
       switch (zoom) {


### PR DESCRIPTION
Sorry, that I can't figure out how to push to my other branch with my other pull request. 

This branch has the changes suggested in the conversation from my last pull request:  https://github.com/simplegeo/polymaps/pull/64

Mainly there is a new "zoom" mode called `pan` which makes the map pan instead of zoom when a mouse wheel is used.  I agree that keeping to the existing API is best even if it isn't semantically accurate for the `zoom` method.  Maybe adding a `mode` function and having the `zoom` function be a copy of it and updating the documentation would be good.  That way you could slowly transition to something more semantic but wouldn't have to do it now.  You could even add a deprecation warning to those using an unminified version of polymaps.js.
