### PR TITLE
Add lockTiles property to a Layer

### DIFF
--- a/src/Layer.js
+++ b/src/Layer.js
@@ -101,11 +101,11 @@ po.layer = function(load, unload) {
         c1 = map.pointCoordinate(tileCenter, {x: mapSize.x, y: 0}),
         c2 = map.pointCoordinate(tileCenter, mapSize),
         c3 = map.pointCoordinate(tileCenter, {x: 0, y: mapSize.y});
-    
+
     function positionTiles(locks) {
       // position tiles
-      for (var key in newLocks) {
-        var t = newLocks[key],
+      for (var key in locks) {
+        var t = locks[key],
             k = Math.pow(2, t.level = t.zoom - tileCenter.zoom);
         t.element.setAttribute("transform", "translate("
           + (t.x = tileSize.x * (t.column - tileCenter.column * k)) + ","


### PR DESCRIPTION
This allows you to improve performance when you know how you are going to be manipulating the map.  It locks the tiles in a layer to those that are currently visible, so zooming or panning won't try and load new tiles (which can be expensive to calculate).  This addresses issue #51.

I still like my suggestion in the conversation of issue #51 for being able to define tileAreas for complete control, but do agree that this is the simplest solution while still getting the performance gains.

And 'lockTiles' is 10,000 times better a name for this property than my original suggestion.
