### PR TITLE
Add custom XHR support to Polymaps

### DIFF
--- a/src/Queue.js
+++ b/src/Queue.js
@@ -27,7 +27,7 @@ po.queue = (function() {
       }
       req.open("GET", url, true);
 
-      for(var key in headers) if(header.hasOwnProperty(key)) {
+      for(var key in headers) if(headers.hasOwnProperty(key)) {
         if(headers[key])
           req.setRequestHeader(key, headers[key])
       }

--- a/src/Queue.js
+++ b/src/Queue.js
@@ -1,5 +1,5 @@
 po.queue = (function() {
-  var queued = [], active = 0, size = 6;
+  var queued = [], active = 0, size = 6, headers = {};
 
   function process() {
     if ((active >= size) || !queued.length) return;
@@ -26,6 +26,12 @@ po.queue = (function() {
         req.overrideMimeType(mimeType);
       }
       req.open("GET", url, true);
+
+      for(var key in headers) if(header.hasOwnProperty(key)) {
+        if(headers[key])
+          req.setRequestHeader(key, headers[key])
+      }
+
       req.onreadystatechange = function(e) {
         if (req.readyState == 4) {
           active--;
@@ -99,5 +105,9 @@ po.queue = (function() {
     return {abort: abort};
   }
 
-  return {text: text, xml: xml, json: json, image: image};
+  function header(header, value) {
+    headers[header] = value
+  }
+
+  return {text: text, xml: xml, json: json, image: image, header:header};
 })();


### PR DESCRIPTION
Allows polymaps users to set or unset custom HTTP headers.

``` javascript

// set a header
org.polymaps.queue.header('X-Requested-With', 'XMLHttpRequest')

// unset a header
org.polymaps.queue.header('X-Requested-With')

```
